### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/workflows/api-dependencies.yml
+++ b/.github/workflows/api-dependencies.yml
@@ -56,9 +56,17 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.changes_detected == 'true'
     runs-on: ubuntu-latest
+    # Determine environment based on ref (if tag or dev-dspot branch)
+    environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
     permissions:
       contents: read
       id-token: write
+    # Environment variables are defined at the job level
+    env:
+      # These values come from the environment configuration in GitHub
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY_DEPENDENCIES: ${{ vars.ECR_REPOSITORY_DEPENDENCIES }}
 
     steps:
       - name: Checkout Repository
@@ -70,7 +78,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -78,9 +86,9 @@ jobs:
 
       - name: Build dependency images
         run: |
-          docker build -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}:latest-api-dev -f .deploy/dependencies/api/Dockerfile .
-          docker build --build-arg ENVIRONMENT=production -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}:latest-api-prod -f .deploy/dependencies/api/Dockerfile .
+          docker build -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}:latest-api-dev -f .deploy/dependencies/api/Dockerfile .
+          docker build --build-arg ENVIRONMENT=production -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}:latest-api-prod -f .deploy/dependencies/api/Dockerfile .
 
       - name: Push images to Amazon ECR
         run: |
-          docker push ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }} --all-tags
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }} --all-tags

--- a/.github/workflows/aws-deploy-api.yml
+++ b/.github/workflows/aws-deploy-api.yml
@@ -2,7 +2,9 @@ name: Deploy API to AWS
 
 on:
   push:
-    branches: [master, dev]
+    branches: [dev-dspot]
+    tags:
+      - 'v*'
     paths:
       - 'apps/api/**/*.*'
       - 'packages/auth/**/*.*'
@@ -43,9 +45,20 @@ jobs:
     name: Deploy API to AWS
     needs: check-dependencies
     runs-on: ubuntu-latest
+    # Define which environment to use based on branch or tag
+    environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
     permissions:
       contents: read
       id-token: write
+    # Environment variables are now defined at the job level
+    env:
+      # These values come from the environment configuration in GitHub
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY_API: ${{ vars.ECR_REPOSITORY_API }}
+      ECR_REPOSITORY_DEPENDENCIES: ${{ vars.ECR_REPOSITORY_DEPENDENCIES }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE_API: ${{ vars.ECS_SERVICE_API }}
 
     steps:
       - name: Checkout Repository
@@ -55,7 +68,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -65,18 +78,18 @@ jobs:
         env:
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --build-arg GIT_HASH="${{ github.sha }}" --build-arg DEPENDENCIES_IMAGE="${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}" -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_API }}:$IMAGE_TAG -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_API }}:latest -f .deploy/api/Dockerfile .
+          docker build --build-arg GIT_HASH="${{ github.sha }}" --build-arg DEPENDENCIES_IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}" -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_API }}:$IMAGE_TAG -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_API }}:latest -f .deploy/api/Dockerfile .
 
       - name: Push API image to Amazon ECR
         env:
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker push ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_API }} --all-tags
-          echo "api_image=${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_API }}:$IMAGE_TAG" >> $GITHUB_ENV
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_API }} --all-tags
+          echo "api_image=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_API }}:$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Update API ECS service
         run: |
           aws ecs update-service \
-            --cluster ${{ vars.ECS_CLUSTER }} \
-            --service ${{ vars.ECS_SERVICE_API }} \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE_API }} \
             --force-new-deployment

--- a/.github/workflows/aws-deploy-webapp.yml
+++ b/.github/workflows/aws-deploy-webapp.yml
@@ -2,7 +2,9 @@ name: Deploy WebApp to AWS
 
 on:
   push:
-    branches: [master, dev]
+    branches: [dev-dspot]
+    tags:
+      - 'v*'
     paths:
       - 'apps/gauzy/**/*.*'
       - 'packages/contracts/**/*.*'
@@ -24,9 +26,20 @@ jobs:
     name: Deploy WebApp to AWS
     needs: check-web-dependencies
     runs-on: ubuntu-latest
+    # Define which environment to use based on branch or tag
+    environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
     permissions:
       contents: read
       id-token: write
+    # Environment variables are now defined at the job level
+    env:
+      # These values come from the environment configuration in GitHub
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY_WEBAPP: ${{ vars.ECR_REPOSITORY_WEBAPP }}
+      ECR_REPOSITORY_DEPENDENCIES: ${{ vars.ECR_REPOSITORY_DEPENDENCIES }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE_WEBAPP: ${{ vars.ECS_SERVICE_WEBAPP }}
 
     steps:
       - name: Checkout Repository
@@ -36,7 +49,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -46,20 +59,20 @@ jobs:
         env:
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --build-arg DEPENDENCIES_IMAGE="${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}:latest-webapp" -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_WEBAPP }}:$IMAGE_TAG -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_WEBAPP }}:latest -f .deploy/webapp/Dockerfile .
+          docker build --build-arg DEPENDENCIES_IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}:latest-webapp" -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_WEBAPP }}:$IMAGE_TAG -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_WEBAPP }}:latest -f .deploy/webapp/Dockerfile .
 
       - name: Push WebApp image to Amazon ECR
         run: |
-          docker push ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_WEBAPP }} --all-tags
-          echo "webapp_image=${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_WEBAPP }}:$IMAGE_TAG" >> $GITHUB_ENV
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_WEBAPP }} --all-tags
+          echo "webapp_image=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_WEBAPP }}:$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Update WebApp ECS service
         run: |
           aws ecs update-service \
-            --cluster ${{ vars.ECS_CLUSTER }} \
-            --service ${{ vars.ECS_SERVICE_WEBAPP }} \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --service ${{ env.ECS_SERVICE_WEBAPP }} \
             --force-new-deployment
 
           aws ecs wait services-stable \
-            --cluster ${{ vars.ECS_CLUSTER }} \
-            --services ${{ vars.ECS_SERVICE_WEBAPP }}
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE_WEBAPP }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,16 +7,24 @@ on:
     workflows: ['Generate dependencies image']
     types:
       - completed
-    branches: [master, dev]
+    branches: [dev-dspot]
   workflow_dispatch:
 
 jobs:
   deploy-api:
     name: Run linter code analysis
     runs-on: ubuntu-latest
+    # Only run on staging environment
+    environment: staging
     permissions:
       contents: read
       id-token: write
+    # Environment variables are defined at the job level
+    env:
+      # These values come from the environment configuration in GitHub
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY_DEPENDENCIES: ${{ vars.ECR_REPOSITORY_DEPENDENCIES }}
 
     steps:
       - name: Checkout Repository
@@ -26,7 +34,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -34,7 +42,7 @@ jobs:
 
       - name: Build image with updated source code
         run: |
-          docker build --build-arg DEPENDENCIES_IMAGE="${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}:latest" -t guazy-code -f .deploy/code-analysis/Dockerfile .
+          docker build --build-arg DEPENDENCIES_IMAGE="${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}:latest" -t guazy-code -f .deploy/code-analysis/Dockerfile .
 
       - name: Run linter
         run: |

--- a/.github/workflows/webapp-dependencies.yml
+++ b/.github/workflows/webapp-dependencies.yml
@@ -56,9 +56,17 @@ jobs:
     needs: check-web-changes
     if: needs.check-web-changes.outputs.changes_detected == 'true'
     runs-on: ubuntu-latest
+    # Determine environment based on ref (if tag or dev-dspot branch)
+    environment: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
     permissions:
       contents: read
       id-token: write
+    # Environment variables are defined at the job level
+    env:
+      # These values come from the environment configuration in GitHub
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY_DEPENDENCIES: ${{ vars.ECR_REPOSITORY_DEPENDENCIES }}
 
     steps:
       - name: Checkout Repository
@@ -70,7 +78,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -78,8 +86,8 @@ jobs:
 
       - name: Build dependency images
         run: |
-          docker build -t ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }}:latest-webapp -f .deploy/dependencies/webapp/Dockerfile .
+          docker build -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }}:latest-webapp -f .deploy/dependencies/webapp/Dockerfile .
 
       - name: Push images to Amazon ECR
         run: |
-          docker push ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY_DEPENDENCIES }} --all-tags
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY_DEPENDENCIES }} --all-tags


### PR DESCRIPTION
This PR migrates the CI/CD workflows from using repository-level variables to environment-specific variables. 
The changes enable a proper separation between staging and production environments, with staging deployments triggered from the dev-dspot branch and production deployments triggered from version tags.
