### PR TITLE
feat: refresh task selector based on real-time task updates

### DIFF
--- a/packages/ui-core/core/src/lib/services/tasks/index.ts
+++ b/packages/ui-core/core/src/lib/services/tasks/index.ts
@@ -5,3 +5,4 @@ export * from './statuses.service';
 export * from './tasks-store.service';
 export * from './tasks.service';
 export * from './team-tasks-store.service';
+export * from './task-socket.service';

--- a/packages/ui-core/core/src/lib/services/tasks/task-socket.service.ts
+++ b/packages/ui-core/core/src/lib/services/tasks/task-socket.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { SocketConnectionService } from "../socket-connection";
+import { BehaviorSubject, filter, fromEvent, switchMap, tap } from "rxjs";
+
+@UntilDestroy()
+@Injectable({
+    providedIn: 'root'
+})
+export class TaskSocketService {
+    public tasksChanged$ = new BehaviorSubject<boolean>(false);
+
+    constructor(private readonly socketConnection: SocketConnectionService) {
+        this.listenToTasksChanges();
+    }
+
+    /**
+     * Listen to tasks changes from the socket connection
+     */
+    private listenToTasksChanges() {
+        console.log(this.socketConnection?.socket);
+        this.socketConnection.connected$
+            .pipe(
+                filter((connected) => connected === true),
+                switchMap(() =>
+                   fromEvent(this.socketConnection.socket, 'tasks:changed').pipe(
+                    tap(() => {
+                        console.log('[Socket] tasks:changed event');
+                        this.tasksChanged$.next(true);
+                    })
+                   )
+                ),
+                untilDestroyed(this)
+            )
+            .subscribe();
+    }
+}

--- a/packages/ui-core/shared/src/lib/tasks/task-select/task/task.component.ts
+++ b/packages/ui-core/shared/src/lib/tasks/task-select/task/task.component.ts
@@ -6,6 +6,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { IOrganization, ITask, PermissionsEnum, TaskStatusEnum } from '@gauzy/contracts';
 import { distinctUntilChange } from '@gauzy/ui-core/common';
 import { AuthService, Store, TasksService, ToastrService } from '@gauzy/ui-core/core';
+import { TaskSocketService } from '@gauzy/ui-core/core';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -136,7 +137,8 @@ export class TaskSelectorComponent implements OnInit, ControlValueAccessor {
 		private readonly tasksService: TasksService,
 		private readonly toastrService: ToastrService,
 		private readonly store: Store,
-		private readonly authService: AuthService
+		private readonly authService: AuthService,
+		private readonly taskSocketService: TaskSocketService
 	) {}
 
 	onChange: any = () => {};
@@ -151,6 +153,13 @@ export class TaskSelectorComponent implements OnInit, ControlValueAccessor {
 			.pipe(
 				debounceTime(50),
 				tap(() => this.getTasks()),
+				untilDestroyed(this)
+			)
+			.subscribe();
+		this.taskSocketService.tasksChanged$
+			.pipe(
+				filter((changed) => changed === true && !!this.organization),
+				tap(() => this.subject$.next(true)),
 				untilDestroyed(this)
 			)
 			.subscribe();


### PR DESCRIPTION
Card: [Exclude “Done” Tasks from Timer](https://trello.com/c/IDzHvEaF/431-exclude-done-tasks-from-timer?filter=member%3Avictoralfonsoestefanoroman)

A new socket signal is emitted whenever a task is updated, allowing the UI to detect changes immediately. This enables the task selector to refresh its list as soon as a task is modified, ensuring that employees see updated assignments without having to reload the page.

This behavior is especially important when an employee is added to or removed from a task, as the selector now reflects these changes instantly. The logic to exclude tasks with a "done" status remains unchanged.
