### PR TITLE
GZY-437: Restrict task visibility to employee’s own projects in ERP

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/project-management/project-management-details/project-management-details.component.ts
@@ -23,10 +23,10 @@ import { MyTaskDialogComponent } from '../../../tasks/components/my-task-dialog/
 
 @UntilDestroy({ checkProperties: true })
 @Component({
-    selector: 'gauzy-project-management-details',
-    templateUrl: './project-management-details.component.html',
-    styleUrls: ['./project-management-details.component.scss'],
-    standalone: false
+	selector: 'gauzy-project-management-details',
+	templateUrl: './project-management-details.component.html',
+	styleUrls: ['./project-management-details.component.scss'],
+	standalone: false
 })
 export class ProjectManagementDetailsComponent extends PaginationFilterBaseComponent implements OnInit, OnDestroy {
 	private _smartTableSource: ServerDataSource;
@@ -109,7 +109,7 @@ export class ProjectManagementDetailsComponent extends PaginationFilterBaseCompo
 			where: {
 				organizationId,
 				tenantId,
-				...(this.selectedEmployeeId ? { employeeId: this.selectedEmployeeId } : {}),
+				...(this.selectedEmployeeId ? { members: { id: this.selectedEmployeeId } } : {}),
 				...(this.selectedProjectId ? { projectId: this.selectedProjectId } : {}),
 				...(this.filters.where ? this.filters.where : {})
 			}
@@ -237,5 +237,7 @@ export class ProjectManagementDetailsComponent extends PaginationFilterBaseCompo
 		this._router.navigate(['/pages/tasks/me']);
 	}
 
-	ngOnDestroy(): void {}
+	ngOnDestroy(): void {
+		// No cleanup needed - subscriptions are handled by async pipe
+	}
 }

--- a/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
+++ b/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
@@ -28,7 +28,7 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 	 * @returns The find conditions based on the current user's relationship with employees.
 	 */
 	private findConditionsWithEmployeeByUser(): FindOptionsWhere<T> {
-		const employeeId = RequestContext.currentEmployeeId();
+		const employeeId = RequestContext.currentUser().employeeId;
 		return (
 			/**
 			 * If the employee has logged in, retrieve their own data unless
@@ -36,8 +36,9 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 			 */
 			(
 				isNotEmpty(employeeId)
-					? !RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE) &&
-					  this.typeOrmRepository.metadata?.hasColumnWithPropertyPath('employeeId')
+					? (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
+					  || RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY))
+					  && this.typeOrmRepository.metadata?.hasColumnWithPropertyPath('employeeId')
 						? {
 								employee: {
 									id: employeeId

--- a/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
+++ b/packages/core/src/lib/core/crud/tenant-aware-crud.service.ts
@@ -28,7 +28,7 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 	 * @returns The find conditions based on the current user's relationship with employees.
 	 */
 	private findConditionsWithEmployeeByUser(): FindOptionsWhere<T> {
-		const employeeId = RequestContext.currentUser().employeeId;
+		const employeeId = RequestContext.currentEmployeeId();
 		return (
 			/**
 			 * If the employee has logged in, retrieve their own data unless
@@ -36,9 +36,8 @@ export abstract class TenantAwareCrudService<T extends TenantBaseEntity>
 			 */
 			(
 				isNotEmpty(employeeId)
-					? (!RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
-					  || RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY))
-					  && this.typeOrmRepository.metadata?.hasColumnWithPropertyPath('employeeId')
+					? !RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE) &&
+					  this.typeOrmRepository.metadata?.hasColumnWithPropertyPath('employeeId')
 						? {
 								employee: {
 									id: employeeId

--- a/packages/core/src/lib/database/migrations/1763105402336-MigrateRolePermissions.ts
+++ b/packages/core/src/lib/database/migrations/1763105402336-MigrateRolePermissions.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as chalk from 'chalk';
+import { DatabaseTypeEnum } from '@gauzy/config';
+import { RolePermissionUtils } from '../../role-permission/utils';
+
+export class MigrateRolePermissions1763105402336 implements MigrationInterface {
+	name = 'MigrateRolePermissions1763105402336';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		console.log(chalk.yellow(`${this.constructor.name} start running!`));
+
+		switch (queryRunner.connection.options.type) {
+			case DatabaseTypeEnum.sqlite:
+			case DatabaseTypeEnum.betterSqlite3:
+			case DatabaseTypeEnum.postgres:
+			case DatabaseTypeEnum.mysql:
+				try {
+					await RolePermissionUtils.migrateRolePermissions(queryRunner);
+				} catch (error) {
+					console.log(chalk.red(`Error while migrating missing role permisions: ${error}`));
+				}
+				break;
+			default:
+				throw Error(`Unsupported database: ${queryRunner.connection.options.type}`);
+		}
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		// This migration cannot be reverted - permission changes are data-dependent
+	}
+}

--- a/packages/core/src/lib/organization-project/organization-project.service.ts
+++ b/packages/core/src/lib/organization-project/organization-project.service.ts
@@ -16,7 +16,8 @@ import {
 	IPagination,
 	RolesEnum,
 	EntitySubscriptionTypeEnum,
-	ITimeLog
+	ITimeLog,
+	PermissionsEnum
 } from '@gauzy/contracts';
 import { getConfig } from '@gauzy/config';
 import { CustomEmbeddedFieldConfig } from '@gauzy/common';
@@ -445,6 +446,37 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 			query.andWhere(`project_team.id = :organizationTeamId`, { organizationTeamId });
 		}
 
+		const userEmployeeId = RequestContext.currentUser().employeeId;
+		if (
+			employeeId !== userEmployeeId &&
+			RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)
+		) {
+			query.andWhere((qb: SelectQueryBuilder<OrganizationProject>) => {
+				const subQuery = qb.subQuery();
+				subQuery
+					.select(p('"project"."id" AS "id"'))
+					.from('organization_project', 'project')
+					.innerJoin('project.members', 'project_members');
+
+				subQuery
+					.where(p('"project_members"."employeeId" = :userEmployeeId'), { userEmployeeId })
+					.andWhere(p('"project"."tenantId" = :tenantId'), { tenantId })
+					.andWhere(p('"project"."organizationId" = :organizationId'), { organizationId });
+
+				if (isNotEmpty(organizationContactId)) {
+					subQuery.andWhere(p('"project"."organizationContactId" = :organizationContactId'), {
+						organizationContactId
+					});
+				}
+
+				if (isNotEmpty(organizationTeamId)) {
+					subQuery.andWhere(p('"project_team"."id" = :organizationTeamId'), { organizationTeamId });
+				}
+
+				return p(`"${query.alias}"."id" IN `) + subQuery.distinct(true).getQuery();
+			});
+		}
+
 		// Get the results
 		return query.getMany();
 	}
@@ -459,6 +491,15 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 		// Check and handle the case where `organizationContactId` is explicitly set to 'null'
 		if (options?.where?.organizationContactId === 'null') {
 			options.where.organizationContactId = IsNull();
+		}
+
+		const userEmployeeId = RequestContext.currentUser().employeeId;
+		if (isNotEmpty(userEmployeeId) && RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+			options.where.members = {
+				employee: {
+					id: userEmployeeId
+				}
+			};
 		}
 
 		// Call the parent class's findAll method with the modified options
@@ -525,6 +566,17 @@ export class OrganizationProjectService extends TenantAwareCrudService<Organizat
 					}
 				};
 			}
+		}
+
+		if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+			const employeeAssignedProjects = await this.typeOrmOrganizationProjectEmployeeRepository.find({
+				where: {
+					employeeId: RequestContext.currentUser().employeeId,
+					organizationId: options.where.organizationId
+				}
+			});
+
+			options.where.id = In(employeeAssignedProjects.map((employee) => employee.organizationProjectId));
 		}
 
 		// Call the parent class's paginate method with the modified options

--- a/packages/core/src/lib/role-permission/default-role-permissions.ts
+++ b/packages/core/src/lib/role-permission/default-role-permissions.ts
@@ -500,6 +500,7 @@ export const DEFAULT_ROLE_PERMISSIONS = [
 			PermissionsEnum.PROJECT_MODULE_READ,
 			PermissionsEnum.PROJECT_MODULE_UPDATE,
 			PermissionsEnum.PROJECT_MODULE_DELETE,
+			PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY,
 			/** Dashboard */
 			PermissionsEnum.DASHBOARD_CREATE,
 			PermissionsEnum.DASHBOARD_READ,
@@ -569,7 +570,83 @@ export const DEFAULT_ROLE_PERMISSIONS = [
 	},
 	{
 		role: RolesEnum.MANAGER,
-		defaultEnabledPermissions: [PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY]
+		defaultEnabledPermissions: [
+			/** Dashboards */
+			PermissionsEnum.TEAM_DASHBOARD,
+			PermissionsEnum.PROJECT_MANAGEMENT_DASHBOARD,
+			PermissionsEnum.TIME_TRACKING_DASHBOARD,
+			PermissionsEnum.DASHBOARD_READ,
+			/** Employee Selection */
+			PermissionsEnum.SELECT_EMPLOYEE,
+			PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
+			PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+			PermissionsEnum.ORG_EMPLOYEES_VIEW,
+			/** Tasks */
+			PermissionsEnum.ORG_TASK_ADD,
+			PermissionsEnum.ORG_TASK_VIEW,
+			PermissionsEnum.ORG_TASK_EDIT,
+			PermissionsEnum.ORG_TASK_DELETE,
+			PermissionsEnum.ORG_TASK_SETTING,
+			PermissionsEnum.ORG_TEAM_EDIT_ACTIVE_TASK,
+			/** Time Off */
+			PermissionsEnum.TIME_OFF_ADD,
+			PermissionsEnum.TIME_OFF_VIEW,
+			PermissionsEnum.TIME_OFF_EDIT,
+			PermissionsEnum.TIME_OFF_DELETE,
+			/** Approvals */
+			PermissionsEnum.APPROVAL_POLICY_VIEW,
+			PermissionsEnum.REQUEST_APPROVAL_EDIT,
+			PermissionsEnum.REQUEST_APPROVAL_VIEW,
+			/** Projects */
+			PermissionsEnum.ACCESS_PRIVATE_PROJECTS,
+			PermissionsEnum.ORG_PROJECT_VIEW,
+			PermissionsEnum.ORG_PROJECT_EDIT,
+			PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY,
+			/** Timesheet */
+			PermissionsEnum.TIMESHEET_EDIT_TIME,
+			PermissionsEnum.CAN_APPROVE_TIMESHEET,
+			/** Invoices */
+			PermissionsEnum.INVOICES_VIEW,
+			PermissionsEnum.INVOICES_EDIT,
+			/** Tags */
+			PermissionsEnum.ORG_TAGS_ADD,
+			PermissionsEnum.ORG_TAGS_VIEW,
+			PermissionsEnum.ORG_TAGS_EDIT,
+			PermissionsEnum.ORG_TAGS_DELETE,
+			/** Sprints */
+			PermissionsEnum.ORG_SPRINT_ADD,
+			PermissionsEnum.ORG_SPRINT_EDIT,
+			PermissionsEnum.ORG_SPRINT_VIEW,
+			PermissionsEnum.ORG_SPRINT_DELETE,
+			/** Contacts */
+			PermissionsEnum.ORG_CONTACT_VIEW,
+			/** Daily Plans */
+			PermissionsEnum.DAILY_PLAN_CREATE,
+			PermissionsEnum.DAILY_PLAN_READ,
+			PermissionsEnum.DAILY_PLAN_UPDATE,
+			PermissionsEnum.DAILY_PLAN_DELETE,
+			/** Project Modules */
+			PermissionsEnum.PROJECT_MODULE_CREATE,
+			PermissionsEnum.PROJECT_MODULE_READ,
+			PermissionsEnum.PROJECT_MODULE_UPDATE,
+			PermissionsEnum.PROJECT_MODULE_DELETE,
+			/** Teams */
+			PermissionsEnum.ORG_TEAM_ADD,
+			PermissionsEnum.ORG_TEAM_VIEW,
+			PermissionsEnum.ORG_TEAM_EDIT,
+			PermissionsEnum.ORG_TEAM_JOIN_REQUEST_VIEW,
+			PermissionsEnum.ORG_TEAM_JOIN_REQUEST_EDIT,
+			/** Other */
+			PermissionsEnum.EVENT_TYPES_VIEW,
+			PermissionsEnum.TIME_TRACKER,
+			PermissionsEnum.MEDIA_GALLERY_VIEW,
+			PermissionsEnum.EQUIPMENT_APPROVE_REQUEST,
+			/** Time Management */
+			PermissionsEnum.ALLOW_DELETE_TIME,
+			PermissionsEnum.ALLOW_MODIFY_TIME,
+			PermissionsEnum.ALLOW_MANUAL_TIME,
+			PermissionsEnum.DELETE_SCREENSHOTS
+		]
 	},
 	{
 		role: RolesEnum.VIEWER,

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -1039,7 +1039,7 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			}
 
 			// Apply filters for organizationSprintId, setting null if not a valid UUID
-			if (isNotEmpty(organizationSprintId) && !isUUID(organizationSprintId)) {
+			if ((isNotEmpty(organizationSprintId) && !isUUID(organizationSprintId)) || organizationSprintId === 'null') {
 				options.where.organizationSprintId = IsNull();
 			}
 

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -39,7 +39,7 @@ import {
 	ITimeLog,
 	TaskStatusEnum
 } from '@gauzy/contracts';
-import { isNotEmpty } from '@gauzy/utils';
+import { isEmpty, isNotEmpty } from '@gauzy/utils';
 import { isSqlite } from '@gauzy/config';
 import { TenantAwareCrudService, PaginationParams } from './../core/crud';
 import { addBetween, LIKE_OPERATOR } from './../core/util';
@@ -173,7 +173,7 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			if (updatedTask.status === TaskStatusEnum.DONE && task.status !== TaskStatusEnum.DONE) {
 				try {
 					this.logger.debug(`Task ${updatedTask.id} changed status to DONE`);
-					this._socketService.sendTimerChangedMany([...existingMemberIdSet])
+					this._socketService.sendTimerChangedMany([...existingMemberIdSet]);
 				} catch (error) {
 					this.logger.error(`Error emitting DONE status event for task ${updatedTask.id}: ${error}`);
 				}
@@ -241,13 +241,9 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			}
 
 			try {
-				[
-					...existingMemberIdSet,
-					...newMembers.map((member) => member.id)
-				].forEach((memberId) => {
+				[...existingMemberIdSet, ...newMembers.map((member) => member.id)].forEach((memberId) => {
 					this._socketService.emitToClient(memberId, 'tasks:changed', null);
 				});
-
 			} catch (error) {
 				this.logger.error(`Error while sending tasks changed event: ${error}`);
 			}
@@ -302,13 +298,54 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async findAll(options: PaginationParams<Task> & IAdvancedTaskFiltering): Promise<IPagination<Task>> {
 		try {
-			const { filters } = options;
-			let advancedFilters: FindOptionsWhere<Task> = {};
-			if (filters) {
-				advancedFilters = this.buildAdvancedWhereCondition(filters, options.where);
+			const { filters, where } = options;
+
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const userEmployeeId = RequestContext.currentUser().employeeId;
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: where?.organizationId as string
+				});
+
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return { items: [], total: 0 };
+				}
+
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+				if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+					return { items: [], total: 0 };
+				}
+
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
+						return { items: [], total: 0 };
+					}
+
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
+				}
 			}
 
-			return super.findAll({ ...options, where: { ...advancedFilters, ...options.where } });
+			let advancedFilters: FindOptionsWhere<Task> = {};
+			if (isNotEmpty(options) && isNotEmpty(options.filters)) {
+				advancedFilters = this.buildAdvancedWhereCondition(options.filters, where);
+			}
+
+			return super.findAll({ ...options, where: { ...advancedFilters, ...where } });
 		} catch (error) {
 			console.log(error);
 			throw new BadRequestException(error);
@@ -492,84 +529,66 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async getEmployeeTasks(options: PaginationParams<Task> & IAdvancedTaskFiltering) {
 		try {
-			const { where } = options;
-			const { members } = where;
+			const { where, filters } = options;
+			const { members, organizationId } = where;
 
-			const hasPermission =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				!RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-			const isManager =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const userEmployeeId = RequestContext.currentUser().employeeId;
+
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: organizationId as string
+				});
+
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return { items: [], total: 0 };
+				}
+
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+				// If project filter is set and not assigned to the current user, return empty result
+				if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+					return { items: [], total: 0 };
+				}
+
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
+						return { items: [], total: 0 };
+					}
+
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
+				}
+			}
 
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
 			query.innerJoin(`${query.alias}.members`, 'members');
 
-			if (!hasPermission || isManager) {
-				// Employee without permission: get their projects first
-				const employeeId = RequestContext.currentEmployeeId() ?? RequestContext.currentUser().employeeId;
-				if (isNotEmpty(employeeId)) {
-					const tenantId = RequestContext.currentTenantId();
-					const organizationId = where?.organizationId as string;
-
-					const projects = await this._organizationProjectService.findByEmployee(employeeId, {
-						tenantId,
-						organizationId,
-						relations: ['members']
-					});
-
-					const projectIds = projects.map((p) => p.id);
-
-					if (projectIds.length === 0) {
-						// No projects -> return empty
-						return { items: [], total: 0 };
-					}
-
-					query.innerJoin(`${query.alias}.project`, 'project');
-					query.andWhere('project.id IN (:...projectIds)', { projectIds });
-				}
-			}
-
-			// Now add the task_employee filter (sync)
 			query.andWhere((qb: SelectQueryBuilder<Task>) => {
 				const subQuery = qb.subQuery();
 				subQuery.select(p('"task_employee"."taskId"')).from(p('task_employee'), p('task_employee'));
 
-				if (hasPermission) {
-					if (isNotEmpty(members) && isNotEmpty(members['id'])) {
-						const employeeId = members['id'];
-						subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), { employeeId });
-					}
-				} else if (isManager) {
-					const selectedEmployeeId = members?.['id'];
-					const managerId = RequestContext.currentUser().employeeId;
+				// If user have permission to change employee get the employee id from the members filter
+				// If employee has login and don't have permission to change employee get the current employee id
+				const employeeId = RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
+					? members?.['id']
+					: RequestContext.currentEmployeeId();
 
-					if (isNotEmpty(selectedEmployeeId) && selectedEmployeeId !== managerId) {
-						subQuery
-							.andWhere(p('"task_employee"."employeeId" = :employeeId'), {
-								employeeId: selectedEmployeeId
-							})
-							.andWhere(
-								`EXISTS (
-					SELECT 1 FROM "task_employee" te2
-					WHERE te2."taskId" = "task_employee"."taskId"
-					AND te2."employeeId" = :managerId
-				)`
-							)
-							.setParameters({ managerId });
-					} else {
-						if (isNotEmpty(managerId)) {
-							subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), {
-								employeeId: managerId
-							});
-						}
-					}
-				} else {
-					// If employee has login and don't have permission to change employee
-					const employeeId = RequestContext.currentEmployeeId();
-					if (isNotEmpty(employeeId)) {
-						subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), { employeeId });
-					}
+				if (isNotEmpty(employeeId)) {
+					subQuery.andWhere(p('"task_employee"."employeeId" = :employeeId'), { employeeId });
 				}
 
 				return p('"task_members"."taskId" IN ') + subQuery.distinct(true).getQuery();
@@ -596,15 +615,58 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async getAllTasksByEmployee(employeeId: IEmployee['id'], options: PaginationParams<Task> & IAdvancedTaskFiltering) {
 		try {
+			const { filters, where } = options;
+			const { isScreeningTask = false } = where;
+
+			// Force to see only assigned projects if user have permission to see only assigned projects
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const userEmployeeId = RequestContext.currentUser().employeeId;
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: where?.organizationId as string
+				});
+
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return [];
+				}
+
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+				// If project filter is set and not assigned to the current user, return empty result
+				if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+					return [];
+				}
+
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
+						return [];
+					}
+
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
+				}
+			}
+
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
 			query.leftJoin(`${query.alias}.members`, 'members');
 			query.leftJoin(`${query.alias}.teams`, 'teams');
-			const { isScreeningTask = false } = options.where;
-			const { filters } = options;
 
 			// Apply advanced filters
-			if (filters) {
-				const advancedWhere = this.buildAdvancedWhereCondition(filters, options.where);
+			if (isNotEmpty(options) && isNotEmpty(options.filters)) {
+				const advancedWhere = this.buildAdvancedWhereCondition(options.filters, where);
 				query.setFindOptions({ where: advancedWhere });
 			}
 
@@ -612,14 +674,8 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			 * If additional options found
 			 */
 			query.setFindOptions({
-				...(isNotEmpty(options) &&
-					isNotEmpty(options.where) && {
-						where: options.where
-					}),
-				...(isNotEmpty(options) &&
-					isNotEmpty(options.relations) && {
-						relations: options.relations
-					})
+				...(isNotEmpty(where) && { where }),
+				...(isNotEmpty(options?.relations) && { relations: options.relations })
 			});
 
 			query.andWhere(
@@ -675,15 +731,58 @@ export class TaskService extends TenantAwareCrudService<Task> {
 		options: PaginationParams<Task> & IAdvancedTaskFiltering
 	) {
 		try {
+			const { filters, where } = options;
+			const { isScreeningTask = false } = where;
+
+			// Force to see only assigned projects if user have permission to see only assigned projects
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const userEmployeeId = RequestContext.currentUser().employeeId;
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: where?.organizationId as string
+				});
+
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return [];
+				}
+
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+				// If project filter is set and not assigned to the current user, return empty result
+				if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+					return [];
+				}
+
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
+						return [];
+					}
+
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
+				}
+			}
+
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
 			query.leftJoin(`${query.alias}.members`, 'members');
 			query.leftJoin(`${query.alias}.teams`, 'teams');
-			const { isScreeningTask = false } = options.where;
-			const { filters } = options;
 
 			// Apply advanced filters
-			if (filters) {
-				const advancedWhere = this.buildAdvancedWhereCondition(filters, options.where);
+			if (isNotEmpty(options) && isNotEmpty(options.filters)) {
+				const advancedWhere = this.buildAdvancedWhereCondition(options.filters, where);
 				query.setFindOptions({ where: advancedWhere });
 			}
 
@@ -691,14 +790,8 @@ export class TaskService extends TenantAwareCrudService<Task> {
 			 * If additional options found
 			 */
 			query.setFindOptions({
-				...(isNotEmpty(options) &&
-					isNotEmpty(options.where) && {
-						where: options.where
-					}),
-				...(isNotEmpty(options) &&
-					isNotEmpty(options.relations) && {
-						relations: options.relations
-					})
+				...(isNotEmpty(where) && { where }),
+				...(isNotEmpty(options?.relations) && { relations: options.relations })
 			});
 
 			query.andWhere(
@@ -754,45 +847,53 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async findTeamTasks(options: PaginationParams<Task> & IAdvancedTaskFiltering): Promise<IPagination<ITask>> {
 		try {
-			const { where } = options;
+			const { where, filters } = options;
 			const { teams = [] } = where;
 			const { members } = where;
 
-			const hasPermission =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				!RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-			const isManager =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
-			query.leftJoin(`${query.alias}.teams`, 'teams');
+			const userEmployeeId = RequestContext.currentUser().employeeId;
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: where?.organizationId as string
+				});
 
-			let projectIds: string[] = [];
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return { items: [], total: 0 };
+				}
 
-			if (!hasPermission || isManager) {
-				const employeeId = RequestContext.currentEmployeeId() ?? RequestContext.currentUser().employeeId;
-				if (isNotEmpty(employeeId)) {
-					const tenantId = RequestContext.currentTenantId();
-					const organizationId = where?.organizationId as string;
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
 
-					const projects = await this._organizationProjectService.findByEmployee(employeeId, {
-						tenantId,
-						organizationId,
-						relations: ['members']
-					});
+				// If project filter is set and not assigned to the current user, return empty result
+				if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+					return { items: [], total: 0 };
+				}
 
-					projectIds = projects.map((p) => p.id);
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
 
-					if (projectIds.length === 0) {
-						// No projects - return empty result early
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
 						return { items: [], total: 0 };
 					}
 
-					// Join project relation and filter by allowed project IDs
-					query.innerJoin(`${query.alias}.project`, 'project');
-					query.andWhere('project.id IN (:...projectIds)', { projectIds });
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
 				}
 			}
+
+			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
+			query.leftJoin(`${query.alias}.teams`, 'teams');
 
 			query.andWhere((qb: SelectQueryBuilder<Task>) => {
 				const subQuery = qb.subQuery();
@@ -803,41 +904,18 @@ export class TaskService extends TenantAwareCrudService<Task> {
 					p('"organization_team_employee"."organizationTeamId" = "task_team"."organizationTeamId"')
 				);
 
-				if (hasPermission) {
+				// If user have permission to change employee
+				if (RequestContext.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)) {
 					if (isNotEmpty(members) && isNotEmpty(members['id'])) {
 						const employeeId = members['id'];
 						subQuery.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), { employeeId });
 					}
-				} else if (isManager) {
-					const selectedEmployeeId = members?.['id'];
-					const managerId = RequestContext.currentUser().employeeId;
-
-					if (isNotEmpty(selectedEmployeeId) && selectedEmployeeId !== managerId) {
-						subQuery
-							.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), {
-								employeeId: selectedEmployeeId
-							})
-							.andWhere(
-								`EXISTS (
-						SELECT 1
-						FROM "organization_team_employee" te
-						WHERE te."organizationTeamId" = "organization_team_employee"."organizationTeamId"
-						  AND te."employeeId" = :managerId
-					)`
-							)
-							.setParameters({ managerId });
-					} else {
-						if (isNotEmpty(managerId)) {
-							subQuery.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), {
-								employeeId: managerId
-							});
-						}
-					}
 				} else {
 					// If employee has login and don't have permission to change employee
-					const employeeId = RequestContext.currentEmployeeId();
-					if (isNotEmpty(employeeId)) {
-						subQuery.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), { employeeId });
+					if (isNotEmpty(userEmployeeId)) {
+						subQuery.andWhere(p('"organization_team_employee"."employeeId" = :employeeId'), {
+							employeeId: userEmployeeId
+						});
 					}
 				}
 
@@ -868,8 +946,49 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @returns A Promise that resolves to a paginated list of tasks.
 	 */
 	public async pagination(options: PaginationParams<Task> & IAdvancedTaskFiltering): Promise<IPagination<ITask>> {
-		const filters = options?.filters;
-		const where = options?.where;
+		const { where, filters } = options;
+
+		// Force to see only assigned projects if user have permission to see only assigned projects
+		if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+			const userEmployeeId = RequestContext.currentUser().employeeId;
+			const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+				tenantId: RequestContext.currentTenantId(),
+				organizationId: where?.organizationId as string
+			});
+
+			// If no projects assigned to the current user, return empty result
+			if (isEmpty(assignedProjects)) {
+				return { items: [], total: 0 };
+			}
+
+			const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+			// If project filter is set and not assigned to the current user, return empty result
+			if (isNotEmpty(where?.projectId) && !assignedProjectIds.has(where.projectId as string)) {
+				return { items: [], total: 0 };
+			}
+
+			if (isNotEmpty(filters?.projects)) {
+				const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+				// If the project filter is set and the projects are not assigned to the current user, return empty result
+				if (isEmpty(projects)) {
+					return { items: [], total: 0 };
+				}
+
+				// Only filter by projects that are assigned to the current user
+				options.filters = {
+					...(filters ?? {}),
+					projects: projects
+				};
+			} else {
+				// If no project filter is set, filter by all projects assigned to the current user
+				options.filters = {
+					...(filters ?? {}),
+					projects: Array.from(assignedProjectIds)
+				};
+			}
+		}
 
 		// Check if there are any filters in the options
 		if (where) {
@@ -931,38 +1050,14 @@ export class TaskService extends TenantAwareCrudService<Task> {
 				};
 			}
 
-			const employeeId = RequestContext.currentEmployeeId();
-			const tenantId = RequestContext.currentTenantId();
-			const organizationId = where.organizationId as string;
-			const hasPermission =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				!RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-			const isManager =
-				RequestContext.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-				RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-			const userProvidedProjectId = !!options.where?.projectId;
-
-			if (!userProvidedProjectId && (isManager || !hasPermission)) {
-				const emplId = employeeId ?? RequestContext.currentUser().employeeId;
-				const projects = await this._organizationProjectService.findByEmployee(emplId, {
-					tenantId,
-					organizationId,
-					relations: ['members']
-				});
-
-				const projectIds = projects.map((p) => p.id);
-
-				options.where.projectId = In(projectIds);
-			}
-
 			// Apply filter for isScreeningTask
 			where.isScreeningTask = isScreeningTask;
 		}
 
 		// Apply Advanced filters
 		let advancedFilters: FindOptionsWhere<Task> = {};
-		if (filters) {
-			advancedFilters = this.buildAdvancedWhereCondition(filters, where);
+		if (isNotEmpty(options) && isNotEmpty(options.filters)) {
+			advancedFilters = this.buildAdvancedWhereCondition(options.filters, options.where);
 		}
 
 		if (options.order?.taskNumber) {
@@ -972,7 +1067,7 @@ export class TaskService extends TenantAwareCrudService<Task> {
 		}
 
 		// Call the base paginate method
-		return await super.paginate({ ...options, where: { ...advancedFilters, ...where } });
+		return await super.paginate({ ...options, where: { ...advancedFilters, ...options.where } });
 	}
 
 	/**
@@ -1122,8 +1217,44 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async findModuleTasks(options: PaginationParams<Task> & IAdvancedTaskFiltering): Promise<IPagination<ITask>> {
 		try {
-			const { where } = options;
+			const { where, filters } = options;
 			const { modules = [], members } = where;
+
+			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
+				const userEmployeeId = RequestContext.currentUser().employeeId;
+				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
+					tenantId: RequestContext.currentTenantId(),
+					organizationId: where?.organizationId as string
+				});
+
+				// If no projects assigned to the current user, return empty result
+				if (isEmpty(assignedProjects)) {
+					return { items: [], total: 0 };
+				}
+
+				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
+
+				if (isNotEmpty(filters?.projects)) {
+					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
+
+					// If the project filter is set and the projects are not assigned to the current user, return empty result
+					if (isEmpty(projects)) {
+						return { items: [], total: 0 };
+					}
+
+					// Only filter by projects that are assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: projects
+					};
+				} else {
+					// If no project filter is set, filter by all projects assigned to the current user
+					options.filters = {
+						...(filters ?? {}),
+						projects: Array.from(assignedProjectIds)
+					};
+				}
+			}
 
 			// Initialize the query
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
@@ -1174,6 +1305,10 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @memberof TaskService
 	 */
 	async findTasksByViewQuery(viewId: ID): Promise<IPagination<ITask>> {
+		// NOTE: This method is currently not being used by the frontend.
+		// When it is going to be used, you must add a filter so that it only shows projects
+		// that are allowed for users who have permission to view only the projects to which they are assigned.
+
 		const tenantId = RequestContext.currentTenantId();
 		try {
 			// Retrieve Task View by ID for getting their pre-defined query params
@@ -1260,6 +1395,10 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @throws {Error} Will throw an error if there is a problem with the database query.
 	 */
 	async getTasksByDateFilters(params: ITaskDateFilterInput): Promise<IPagination<ITask>> {
+		// NOTE: This method is currently not being used by the frontend.
+		// When it is going to be used, you must add a filter so that it only shows projects
+		// that are allowed for users who have permission to view only the projects to which they are assigned.
+
 		const tenantId = RequestContext.currentTenantId() || params.tenantId;
 
 		try {

--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -1217,44 +1217,8 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 */
 	async findModuleTasks(options: PaginationParams<Task> & IAdvancedTaskFiltering): Promise<IPagination<ITask>> {
 		try {
-			const { where, filters } = options;
+			const { where } = options;
 			const { modules = [], members } = where;
-
-			if (RequestContext.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY)) {
-				const userEmployeeId = RequestContext.currentUser().employeeId;
-				const assignedProjects = await this._organizationProjectService.findByEmployee(userEmployeeId, {
-					tenantId: RequestContext.currentTenantId(),
-					organizationId: where?.organizationId as string
-				});
-
-				// If no projects assigned to the current user, return empty result
-				if (isEmpty(assignedProjects)) {
-					return { items: [], total: 0 };
-				}
-
-				const assignedProjectIds = new Set(assignedProjects.map((p) => p.id));
-
-				if (isNotEmpty(filters?.projects)) {
-					const projects = filters.projects.filter((project) => assignedProjectIds.has(project));
-
-					// If the project filter is set and the projects are not assigned to the current user, return empty result
-					if (isEmpty(projects)) {
-						return { items: [], total: 0 };
-					}
-
-					// Only filter by projects that are assigned to the current user
-					options.filters = {
-						...(filters ?? {}),
-						projects: projects
-					};
-				} else {
-					// If no project filter is set, filter by all projects assigned to the current user
-					options.filters = {
-						...(filters ?? {}),
-						projects: Array.from(assignedProjectIds)
-					};
-				}
-			}
 
 			// Initialize the query
 			const query = this.typeOrmRepository.createQueryBuilder(this.tableName);
@@ -1305,10 +1269,6 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @memberof TaskService
 	 */
 	async findTasksByViewQuery(viewId: ID): Promise<IPagination<ITask>> {
-		// NOTE: This method is currently not being used by the frontend.
-		// When it is going to be used, you must add a filter so that it only shows projects
-		// that are allowed for users who have permission to view only the projects to which they are assigned.
-
 		const tenantId = RequestContext.currentTenantId();
 		try {
 			// Retrieve Task View by ID for getting their pre-defined query params
@@ -1395,10 +1355,6 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @throws {Error} Will throw an error if there is a problem with the database query.
 	 */
 	async getTasksByDateFilters(params: ITaskDateFilterInput): Promise<IPagination<ITask>> {
-		// NOTE: This method is currently not being used by the frontend.
-		// When it is going to be used, you must add a filter so that it only shows projects
-		// that are allowed for users who have permission to view only the projects to which they are assigned.
-
 		const tenantId = RequestContext.currentTenantId() || params.tenantId;
 
 		try {

--- a/packages/ui-core/i18n/assets/i18n/ar.json
+++ b/packages/ui-core/i18n/assets/i18n/ar.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "عرض المشاريع المعينة فقط (للأدوار الإدارية)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "يتم عرض المشاريع المعيّنة للموظف فقط",
 			"PROFILE_EDIT": "تعديل الملف الشخصي",
 			"ADMIN_DASHBOARD_VIEW": "عرض لوحة تحكم المسؤول",
 			"TEAM_DASHBOARD": "عرض لوحة تحكم الفريق",

--- a/packages/ui-core/i18n/assets/i18n/bg.json
+++ b/packages/ui-core/i18n/assets/i18n/bg.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Показвай само назначените проекти (за управленски роли)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Показвай само назначените проекти",
 			"PROFILE_EDIT": "Редактиране на профила",
 			"ADMIN_DASHBOARD_VIEW": "Виж админ табло",
 			"TEAM_DASHBOARD": "Виж табло на екипа",

--- a/packages/ui-core/i18n/assets/i18n/de.json
+++ b/packages/ui-core/i18n/assets/i18n/de.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Nur zugewiesene Projekte anzeigen (für Management-Rollen)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Nur zugewiesene Projekte anzeigen",
 			"PROFILE_EDIT": "Profil bearbeiten",
 			"ADMIN_DASHBOARD_VIEW": "Admin-Dashboard anzeigen",
 			"TEAM_DASHBOARD": "Team-Dashboard anzeigen",

--- a/packages/ui-core/i18n/assets/i18n/en.json
+++ b/packages/ui-core/i18n/assets/i18n/en.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Show only assigned projects (for managerial roles)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Show only assigned projects",
 			"PROFILE_EDIT": "Edit profile",
 			"ADMIN_DASHBOARD_VIEW": "View Admin Dashboard",
 			"TEAM_DASHBOARD": "View Team Dashboard",

--- a/packages/ui-core/i18n/assets/i18n/es.json
+++ b/packages/ui-core/i18n/assets/i18n/es.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostrar solo los proyectos asignados (para roles de gestión)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostrar solo los proyectos asignados",
 			"PROFILE_EDIT": "Editar perfil",
 			"ADMIN_DASHBOARD_VIEW": "Ver panel de administración",
 			"TEAM_DASHBOARD": "Ver panel del equipo",

--- a/packages/ui-core/i18n/assets/i18n/fr.json
+++ b/packages/ui-core/i18n/assets/i18n/fr.json
@@ -2046,7 +2046,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Afficher uniquement les projets attribués (pour les rôles de gestion)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Afficher uniquement les projets attribués",
 			"PROFILE_EDIT": "Modifier le profil",
 			"ADMIN_DASHBOARD_VIEW": "Afficher le tableau de bord de l'administrateur",
 			"TEAM_DASHBOARD": "Voir le tableau de bord de l'équipe",

--- a/packages/ui-core/i18n/assets/i18n/he.json
+++ b/packages/ui-core/i18n/assets/i18n/he.json
@@ -2164,7 +2164,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "הצג רק פרויקטים שהוקצו (לתפקידי ניהול)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "הצג רק פרויקטים שהוקצו",
 			"PROFILE_EDIT": "ערוך פרופיל",
 			"ADMIN_DASHBOARD_VIEW": "הצג לוח מחוונים למנהל",
 			"TEAM_DASHBOARD": "הצג לוח מחוונים לצוות",

--- a/packages/ui-core/i18n/assets/i18n/it.json
+++ b/packages/ui-core/i18n/assets/i18n/it.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostra solo i progetti assegnati (per ruoli gestionali)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostra solo i progetti assegnati",
 			"PROFILE_EDIT": "Modifica profilo",
 			"ADMIN_DASHBOARD_VIEW": "Visualizza dashboard admin",
 			"TEAM_DASHBOARD": "Visualizza dashboard team",

--- a/packages/ui-core/i18n/assets/i18n/nl.json
+++ b/packages/ui-core/i18n/assets/i18n/nl.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Toon alleen toegewezen projecten (voor managementrollen)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Toon alleen toegewezen projecten",
 			"PROFILE_EDIT": "Profiel bewerken",
 			"ADMIN_DASHBOARD_VIEW": "Bekijk admin-dashboard",
 			"TEAM_DASHBOARD": "Bekijk team-dashboard",

--- a/packages/ui-core/i18n/assets/i18n/pl.json
+++ b/packages/ui-core/i18n/assets/i18n/pl.json
@@ -2164,7 +2164,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Pokazuj tylko przypisane projekty (dla menedżerskich ról)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Pokazuj tylko przypisane projekty",
 			"PROFILE_EDIT": "Edytuj profil",
 			"ADMIN_DASHBOARD_VIEW": "Wyświetl pulpit administratora",
 			"TEAM_DASHBOARD": "Wyświetl pulpit zespołu",

--- a/packages/ui-core/i18n/assets/i18n/pt.json
+++ b/packages/ui-core/i18n/assets/i18n/pt.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostrar apenas projetos atribuídos (para funções de gestão)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Mostrar apenas projetos atribuídos",
 			"PROFILE_EDIT": "Editar perfil",
 			"ADMIN_DASHBOARD_VIEW": "Ver Painel de Administração",
 			"TEAM_DASHBOARD": "Ver Painel da Equipe",

--- a/packages/ui-core/i18n/assets/i18n/ru.json
+++ b/packages/ui-core/i18n/assets/i18n/ru.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "Показывать только назначенные проекты (для управленческих ролей)",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "Показывать только назначенные проекты",
 			"PROFILE_EDIT": "Редактировать профиль",
 			"ADMIN_DASHBOARD_VIEW": "Просмотр панели администратора",
 			"TEAM_DASHBOARD": "Просмотр панели команды",

--- a/packages/ui-core/i18n/assets/i18n/zh.json
+++ b/packages/ui-core/i18n/assets/i18n/zh.json
@@ -2165,7 +2165,7 @@
 			}
 		},
 		"PERMISSIONS": {
-			"VIEW_ASSIGNED_PROJECTS_ONLY": "仅显示分配的项目（适用于管理角色）",
+			"VIEW_ASSIGNED_PROJECTS_ONLY": "仅显示分配的项目",
 			"PROFILE_EDIT": "编辑个人资料",
 			"ADMIN_DASHBOARD_VIEW": "查看管理员仪表盘",
 			"TEAM_DASHBOARD": "查看团队仪表盘",

--- a/packages/ui-core/shared/src/lib/selectors/project/project/project.component.ts
+++ b/packages/ui-core/shared/src/lib/selectors/project/project/project.component.ts
@@ -185,12 +185,16 @@ export class ProjectSelectorComponent implements OnInit, AfterViewInit {
 
 	/**
 	 * Callback function to notify changes in the form control.
+	 * @remarks This is overridden by Angular's ControlValueAccessor.registerOnChange
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	private onChange: (value: ID | ID[]) => void = () => {};
 
 	/**
 	 * Callback function to notify touch events in the form control.
+	 * @remarks This is overridden by Angular's ControlValueAccessor.registerOnTouched
 	 */
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	private onTouched: () => void = () => {};
 
 	constructor(
@@ -337,13 +341,6 @@ export class ProjectSelectorComponent implements OnInit, AfterViewInit {
 
 		const { id: organizationId, tenantId } = this.organization;
 
-		const isAdmin =
-			this._store.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT) &&
-			!this._store.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY);
-		const isManager =
-			this._store.hasPermission(PermissionsEnum.VIEW_ASSIGNED_PROJECTS_ONLY) &&
-			this._store.hasPermission(PermissionsEnum.ORG_EMPLOYEES_EDIT);
-
 		const queryOptions: IOrganizationProjectsFindInput = {
 			...(this.organizationContactId && { organizationContactId: this.organizationContactId }),
 			organizationId,
@@ -351,27 +348,10 @@ export class ProjectSelectorComponent implements OnInit, AfterViewInit {
 		};
 
 		try {
-			let projects: IOrganizationProject[] = [];
-
-			// ADMIN — full access to all projects
-			if (isAdmin) {
-				const { items } = await this._organizationProjects.getAll([], queryOptions);
-				projects = items || [];
-			}
-			// MANAGER — only projects where the manager is a member
-			else if (isManager) {
-				const managerId = this._store.user.employee?.id;
-				if (managerId) {
-					projects = await this._organizationProjects.getAllByEmployee(managerId, queryOptions);
-				}
-			}
-			// EMPLOYEE — only their own projects
-			else {
-				if (this.employeeId) {
-					projects = await this._organizationProjects.getAllByEmployee(this.employeeId, queryOptions);
-				}
-			}
-			this.projects = projects;
+			// Retrieve projects based on whether employeeId is provided
+			this.projects = this.employeeId
+				? await this._organizationProjects.getAllByEmployee(this.employeeId, queryOptions)
+				: (await this._organizationProjects.getAll([], queryOptions)).items || [];
 
 			// Optionally add "All Projects" option
 			if (this.showAllOption) {


### PR DESCRIPTION
- This change enforces a consistent project-visibility rule across the system, ensuring that both Managers and Employees follow the same assigned-projects restriction.

- The previous behavior allowed Managers to see all projects by default, which conflicted with the intended access-control model and caused inconsistencies in how visibility rules were applied across different endpoints.

- To maintain coherence with the platform's permission model and avoid privilege gaps between roles, the assigned-projects rule was formally applied to Employees as well.

- Backend services that return projects or project-related tasks were updated to ensure permission checks are applied uniformly, preventing accidental exposure of unassigned projects.

- A migration was added to guarantee that roles have the correct permission associations, avoiding environments where outdated role-permission links could break the new visibility logic.

- Minor frontend adjustments were made to fix the employee filter in the project-management dashboard, since incorrect parameter mapping caused the API to receive invalid filter values and could misapply visibility rules.

**Card:** [Restrict Task Visibility to Employee’s Own Projects in ERP](https://trello.com/c/EhgJ3STb/437-restrict-task-visibility-to-employees-own-projects-in-erp?filter=member%3Avictoralfonsoestefanoroman)
