### PR TITLE
feat: my task assigned only

### DIFF
--- a/packages/core/src/lib/tasks/task.service.ts
+++ b/packages/core/src/lib/tasks/task.service.ts
@@ -390,7 +390,13 @@ export class TaskService extends TenantAwareCrudService<Task> {
 	 * @returns
 	 */
 	async getMyTasks(options: PaginationParams<Task> & IAdvancedTaskFiltering) {
-		return await this.getEmployeeTasks(options);
+		const { where } = options;
+
+		const members = {
+			id: RequestContext.currentUser().employeeId as string
+		};
+
+		return await this.getEmployeeTasks({ ...options, where: { ...where, members } });
 	}
 
 	private addTaskCommonFilters(


### PR DESCRIPTION

Depends: #117 

Ensure My Tasks shows only tasks assigned to the logged-in user.

Previously, users with elevated roles as Manager could see all tasks, causing inconsistency and confusion about the purpose of the view.

Now My Tasks always reflects the employee's own assignments, improving clarity and access control.