### PR TITLE
GZY-434: Admin unable to add time for past week 

### DIFF
--- a/packages/core/src/lib/time-tracking/statistic/statistic.service.ts
+++ b/packages/core/src/lib/time-tracking/statistic/statistic.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Brackets, SelectQueryBuilder, WhereExpressionBuilder } from 'typeorm';
 import { reduce, pluck, pick, mapObject, groupBy, chain } from 'underscore';
 import * as moment from 'moment';
@@ -22,7 +22,7 @@ import {
 	IWeeklyStatisticsActivities,
 	ITodayStatisticsActivities
 } from '@gauzy/contracts';
-import { ArraySum, isNotEmpty } from '@gauzy/utils';
+import { ArraySum, isEmpty, isNotEmpty } from '@gauzy/utils';
 import {
 	ConfigService,
 	DatabaseTypeEnum,
@@ -394,6 +394,8 @@ export class StatisticService {
 	async getPeriodStatisticsDuration(request: IGetCountsStatistics): Promise<{ duration: number }> {
 		const {
 			organizationId,
+			employeeId = [],
+			employeeIds = [],
 			startDate,
 			endDate,
 			projectIds = [],
@@ -403,19 +405,31 @@ export class StatisticService {
 			onlyMe: isOnlyMeSelected
 		} = request;
 
-		let employeeIds = request.employeeIds || [];
-
 		const user = RequestContext.currentUser();
 		const tenantId = RequestContext.currentTenantId() ?? request.tenantId;
 
-		// Check if the user has permission to view/change other employees
-		const hasChangeSelectedEmployeePermission: boolean = RequestContext.hasPermission(
+		// Check if the user only can see himself
+		const onlyCanSeeHimself: boolean = isOnlyMeSelected || !RequestContext.hasPermission(
 			PermissionsEnum.CHANGE_SELECTED_EMPLOYEE
 		);
 
-		// If the user does not have permission (or selected "only me"), restrict to their own employeeId
-		if (user.employeeId && (isOnlyMeSelected || !hasChangeSelectedEmployeePermission)) {
-			employeeIds = [user.employeeId];
+		const filteredEmployeeIds = [];
+
+		if (onlyCanSeeHimself) {
+			if (isEmpty(user.employeeId)) {
+				// If not throw an error, the query will return all employees
+				throw new NotFoundException(
+					'No employee profile associated with your user account. Please contact your administrator.'
+				);
+			}
+
+			filteredEmployeeIds.push(user.employeeId);
+		} else {
+			if (isNotEmpty(employeeId)) {
+				filteredEmployeeIds.push(employeeId);
+			} else if (isNotEmpty(employeeIds)) {
+				filteredEmployeeIds.push(...employeeIds);
+			}
 		}
 
 		// Format the date range (default: current ISO week)
@@ -444,8 +458,8 @@ export class StatisticService {
 			);
 
 		// Apply filters conditionally
-		if (isNotEmpty(employeeIds)) {
-			query.andWhere('time_log.employeeId IN (:...employeeIds)', { employeeIds });
+		if (isNotEmpty(filteredEmployeeIds)) {
+			query.andWhere('time_log.employeeId IN (:...employeeIds)', { employeeIds: filteredEmployeeIds });
 		}
 
 		if (isNotEmpty(projectIds)) {

--- a/packages/core/src/lib/time-tracking/timer/timer-weekly-limit.service.ts
+++ b/packages/core/src/lib/time-tracking/timer/timer-weekly-limit.service.ts
@@ -27,9 +27,9 @@ export class TimerWeeklyLimitService {
 			timeZone = 'UTC';
 			throw new Error(`TimeZone is undefined`);
 		}
+
 		const currentUser = RequestContext.currentUser();
-		const isCurrentEmployee = employee.id === currentUser.employeeId;
-		const isOnlyMe = isCurrentEmployee;
+		const isOnlyMe = employee.id === currentUser.employeeId;
 
 		const refMomentLocal = moment.utc(refDate).tz(timeZone);
 
@@ -53,6 +53,7 @@ export class TimerWeeklyLimitService {
 		if (remainWeeklyTime <= 0 && !ignoreException) {
 			throw new ConflictException(TimeErrorsEnum.WEEKLY_LIMIT_REACHED);
 		}
+		
 		return { remainWeeklyTime, workedThisWeek: statistics.duration };
 	}
 


### PR DESCRIPTION
# Ticket
[Admin unable to add time for past week — “weekly-limit-reached” error despite available hours](https://trello.com/c/80LmeREX/434-admin-unable-to-add-time-for-past-week-weekly-limit-reached-error-despite-available-hours)

# Description
What is the change?  
- Updated the getPeriodStatisticsDuration method to improve employee ID filtering based on user permissions.
- Introduced a new filteredEmployeeIds array to ensure that only relevant employee IDs are considered based on the user's access rights.
- Adjusted the timer-weekly-limit service to simplify the logic for determining if the current user is the employee in context.
- These changes enhance data accuracy and maintain consistent access control across the application.

Why is the change needed?  
- These changes were made to unify and clarify how employee filters are handled in
getPeriodStatisticsDuration. The method previously accepted both employeeId and
employeeIds, but their usage was inconsistent. The new logic allows either
parameter to be used reliably for filtering.
- Additionally, a validation was added to prevent users who can only view their own
data from accessing organization-wide results when they do not have an employee
profile. Previously, this scenario returned data for all employees, which was a
security issue.

# How to test the change
- The main flow that needs to be tested is adding time for an employee in the present and the past.
- Try adding time for a user when they have reached the maximum weekly hours.
- Log time for an employee on a task using the time tracker.

# Scope of Changes
- [x] API change
- [ ] Frontend change
- [ ] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [ ] I updated documentation where necessary
- [x] I ran the project and verified the change
- [x] Any dependent tasks/issues are linked above
