### PR TITLE
GZY-491: Project field should display the selected project name when editing generated invoice items

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/table-components/invoice-project-selector.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/table-components/invoice-project-selector.component.ts
@@ -54,7 +54,7 @@ export class InvoiceProjectsSelectorComponent extends DefaultEditor implements O
 
 		this.projects = JSON.parse(JSON.stringify(response));
 		const project = this.cell.getValue();
-		this.project = this.projects.find((p) => p.id === project['id']);
+		this.project = this.projects.find((p) => p.name === project);
 	}
 
 	/**


### PR DESCRIPTION
# Ticket
https://trello.com/c/Iwv4aMBi/491-%D0%BA

# Scope of Changes
- [ ] API change
- [x] Frontend change
- [ ] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [ ] I updated documentation where necessary
- [ ] I ran the project and verified the change
- [ ] Any dependent tasks/issues are linked above
