### PR TITLE
GZY-483 Generate Invoice Items by Project Hours

### DIFF
--- a/packages/contracts/src/lib/timesheet.model.ts
+++ b/packages/contracts/src/lib/timesheet.model.ts
@@ -15,6 +15,7 @@ import { IRelationalOrganizationTeam } from './organization-team.model';
 import { IScreenshot } from './screenshot.model';
 import { TimeFormatEnum } from './organization.model';
 import { IOrganizationEmploymentType } from './organization-employment-type.model';
+import { CurrenciesEnum } from './currency.model';
 
 export interface ITimesheet extends IBasePerTenantAndOrganizationEntityModel {
 	employee: IEmployee;
@@ -391,6 +392,12 @@ export interface IGetTimeLogReportInput extends IGetTimeLogInput {
 	isEdited?: boolean;
 }
 
+export interface IGetInvoiceReportInput extends ITimeLogFilters {
+	isEdited?: boolean;
+	timesheetId?: ID;
+	onlyMe?: boolean;
+}
+
 export interface IGetTimeLogConflictInput extends IBasePerTenantAndOrganizationEntityModel, IBaseRelationsEntityModel {
 	ignoreId?: ID | ID[];
 	startDate: string | Date;
@@ -498,6 +505,30 @@ export type IReportDayData =
 	| IReportDayGroupByEmployee
 	| IReportDayGroupByProject
 	| IReportDayGroupByClient;
+
+export type IProjectBillSummary = {
+	id: ID;
+	name: string;
+	duration: number;
+}
+
+export type IEmployeeBillSummary = {
+	id: ID;
+	firstName: string;
+	lastName: string;
+	userName: string;
+	billRateCurrency: CurrenciesEnum;
+	billRateValue: number;
+	projects: IProjectBillSummary[];
+	subTotalDuration: number;
+	subTotalBillAmount: number;
+}
+
+export type IInvoiceReport = {
+	billingSummary: IEmployeeBillSummary[];
+	totalDuration: number;
+	totalBillAmount: number;
+}
 
 export interface IDailyReportChart {
 	date: string;

--- a/packages/core/src/lib/time-tracking/time-log/dto/query/index.ts
+++ b/packages/core/src/lib/time-tracking/time-log/dto/query/index.ts
@@ -1,2 +1,3 @@
 export * from './time-log-query.dto';
 export * from './time-log-limit-query.dto';
+export * from './invoice-query.dto';

--- a/packages/core/src/lib/time-tracking/time-log/dto/query/invoice-query.dto.ts
+++ b/packages/core/src/lib/time-tracking/time-log/dto/query/invoice-query.dto.ts
@@ -1,0 +1,35 @@
+import { ApiPropertyOptional, IntersectionType } from '@nestjs/swagger';
+import { IsOptional, IsString, IsTimeZone, IsUUID } from 'class-validator';
+import { Transform, TransformFnParams } from 'class-transformer';
+import { IGetInvoiceReportInput, ITimesheet } from '@gauzy/contracts';
+import { parseToBoolean } from '@gauzy/utils';
+import { FiltersQueryDTO, SelectorsQueryDTO } from '../../../../shared/dto';
+
+/**
+ * Get invoice report request DTO validation
+ */
+export class InvoiceQueryDTO
+    extends IntersectionType(FiltersQueryDTO, SelectorsQueryDTO)
+    implements IGetInvoiceReportInput
+{
+    @ApiPropertyOptional({ type: () => String })
+	@IsOptional()
+	@IsUUID()
+	readonly timesheetId: ITimesheet['id'];
+
+    @ApiPropertyOptional({ type: () => String })
+	@IsOptional()
+	@IsString()
+	@IsTimeZone()
+	readonly timeZone: string;
+
+	@ApiPropertyOptional({ type: () => Boolean })
+	@IsOptional()
+	@Transform(({ value }: TransformFnParams) => parseToBoolean(value))
+	readonly isEdited: boolean;
+
+    @ApiPropertyOptional({ type: () => Boolean })
+	@IsOptional()
+	@Transform(({ value }: TransformFnParams) => parseToBoolean(value))
+	readonly onlyMe: boolean;
+}

--- a/packages/core/src/lib/time-tracking/time-log/time-log.controller.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.controller.ts
@@ -26,14 +26,15 @@ import {
 	IAmountOwedReportChart,
 	IDailyReportChart,
 	IGetTimeLogReportInput,
-	IPagination
+	IPagination,
+	IInvoiceReport
 } from '@gauzy/contracts';
 import { TimeLogService } from './time-log.service';
 import { Permissions } from './../../shared/decorators';
 import { OrganizationPermissionGuard, PermissionGuard, TenantBaseGuard } from './../../shared/guards';
 import { UUIDValidationPipe, UseValidationPipe } from './../../shared/pipes';
 import { CreateManualTimeLogDTO, DeleteTimeLogDTO, UpdateManualTimeLogDTO } from './dto';
-import { TimeLogLimitQueryDTO, TimeLogQueryDTO } from './dto/query';
+import { TimeLogLimitQueryDTO, TimeLogQueryDTO, InvoiceQueryDTO } from './dto/query';
 import { TimeLogBodyTransformPipe } from './pipes';
 import { IGetConflictTimeLogCommand } from './commands';
 import { PaginationParams } from '../../core/crud';
@@ -245,6 +246,26 @@ export class TimeLogController {
 	@UseValidationPipe({ whitelist: true, transform: true })
 	async getInvoiceLogs(@Query() options: TimeLogQueryDTO): Promise<IReportDayData> {
 		return await this._timeLogService.getInvoiceLogs(options);
+	}
+
+	/**
+	 * Get invoice based on provided options.
+	 * @param options The options for querying invoice.
+	 * @returns The invoice based on the provided options.
+	 */
+	@ApiOperation({ summary: 'Get Invoice by filters' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Successfully retrieved invoice',
+	})
+	@ApiResponse({
+		status: HttpStatus.BAD_REQUEST,
+		description: 'Invalid input. The response body may contain clues as to what went wrong.'
+	})
+	@Get('invoice/by')
+	@UseValidationPipe({ whitelist: true, transform: true })
+	async getInvoice(@Query() options: InvoiceQueryDTO): Promise<IInvoiceReport> {
+		return await this._timeLogService.getInvoice(options);
 	}
 
 	/**

--- a/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.service.ts
@@ -35,7 +35,10 @@ import {
 	TimeLogPartialStatus,
 	IDeleteTimeLogData,
 	TimeErrorsEnum,
-	IPagination
+	IPagination,
+	CurrenciesEnum,
+	IGetInvoiceReportInput,
+	IInvoiceReport
 } from '@gauzy/contracts';
 import { isEmpty, isNotEmpty } from '@gauzy/utils';
 import { PaginationParams, TenantAwareCrudService } from './../../core/crud';
@@ -53,7 +56,7 @@ import {
 import { getDateRangeFormat, getDaysBetweenDates } from './../../core/utils';
 import { RequestContext } from '../../core/context';
 import { moment } from './../../core/moment-extend';
-import { calculateAverage, calculateAverageActivity, calculateDuration, fixTimeLogsBoundary } from './time-log.utils';
+import { calculateAverage, calculateAverageActivity, calculateDuration, fixTimeLogsBoundary, transformInvoiceData } from './time-log.utils';
 import { prepareSQLQuery as p } from './../../database/database.helper';
 import { TypeOrmTimeLogRepository } from './repository/type-orm-time-log.repository';
 import { MikroOrmTimeLogRepository } from './repository/mikro-orm-time-log.repository';
@@ -64,6 +67,7 @@ import { TimeLog } from './time-log.entity';
 import { ActivityLogService } from '../../activity-log/activity-log.service';
 import { TimerWeeklyLimitService } from '../timer/timer-weekly-limit.service';
 import { SocketService } from '../../socket/socket.service';
+import { environment } from '@gauzy/config';
 
 @Injectable()
 export class TimeLogService extends TenantAwareCrudService<TimeLog> {
@@ -367,6 +371,99 @@ export class TimeLogService extends TenantAwareCrudService<TimeLog> {
 		}
 
 		return invoiceData;
+	}
+
+	/**
+	 * Retrieves invoice data based on the provided input.
+	 * @param request The input parameters for fetching invoice data.
+	 * @returns A Promise that resolves to an invoice report.
+	 */
+	async getInvoice(request: IGetInvoiceReportInput): Promise<IInvoiceReport> {
+		const { employmentTypes } = request;
+
+		const timeLogsDuration = this.typeOrmRepository.createQueryBuilder(this.tableName);
+
+		if (isNotEmpty(employmentTypes)) {
+			timeLogsDuration.innerJoin(`${timeLogsDuration.alias}.employee.organizationEmploymentTypes`, 'organizationEmploymentTypes');
+		}
+
+		/**
+		 * STEP 1 — Build a subquery that normalizes the duration of each time log
+		 * within the requested date window.
+		 *
+		 * This subquery:
+		 *  - Selects employeeId and projectId
+		 *  - Computes the effective duration of each time log that overlaps the range
+		 *  - Ensures we only count the portion of the log that falls inside
+		 *    [startDate, endDate]
+		 */
+		timeLogsDuration.select([
+			p(`"${timeLogsDuration.alias}"."employeeId" AS "employeeId"`),
+			p(`"${timeLogsDuration.alias}"."projectId" AS "projectId"`),
+			p(`
+				EXTRACT(EPOCH FROM (
+					LEAST(COALESCE("${timeLogsDuration.alias}"."stoppedAt", :endDate), :endDate)
+					-
+					GREATEST(COALESCE("${timeLogsDuration.alias}"."startedAt", :startDate), :startDate)
+				)) AS duration`
+			),
+		]);
+
+		timeLogsDuration.where((qb: SelectQueryBuilder<TimeLog>) => {
+			this.getFilterTimeLogQuery(qb, request, true);
+		});
+
+		/**
+		 * STEP 2 — Aggregate the per-log durations into per-(employeeId, projectId).
+		 *
+		 * This query groups by employee and project to produce:
+		 *  - total duration per employee/project pair
+		 *
+		 * Using the subquery prevents recomputing the overlap logic
+		 * and guarantees that the grouping is applied on the normalized data.
+		 */
+		const workingDuration = this.typeOrmRepository.manager.createQueryBuilder()
+		.from(`(${timeLogsDuration.getQuery()})`, 'timeLogsDuration')
+		.select([
+			p(`"timeLogsDuration"."employeeId" AS "employeeId"`),
+            p(`"timeLogsDuration"."projectId" AS "projectId"`),
+            p(`SUM("timeLogsDuration"."duration") AS "totalDuration"`)
+		])
+		.setParameters(timeLogsDuration.getParameters())
+		.groupBy('"timeLogsDuration"."employeeId"')
+		.addGroupBy('"timeLogsDuration"."projectId"');
+
+		/**
+		 * STEP 3 — Join aggregated durations with employee, user, and project metadata.
+		 *
+		 * This produces the final invoice-ready dataset:
+		 *  - Employee info
+		 *  - Project info
+		 *  - Total duration per project
+		 *  - Billing rate data
+		 *  - Calculated bill amount
+		 */
+		const bills = await this.typeOrmRepository.manager.createQueryBuilder()
+		.from(`(${workingDuration.getQuery()})`, 'workingDuration')
+		.innerJoin('employee', 'employee', 'employee.id = "workingDuration"."employeeId"') // Join employee → retrieve billing rate and user reference
+		.innerJoin('user', 'user', 'user.id = employee.userId') // Join user → retrieve names and username
+		.innerJoin('organization_project', 'project', 'project.id = "workingDuration"."projectId"') // Join project → retrieve project name
+		.select([
+			p(`"workingDuration"."employeeId" AS "employeeId"`),
+            p(`"workingDuration"."projectId" AS "projectId"`),
+            p(`"workingDuration"."totalDuration" AS "totalDuration"`),
+            p(`"user"."firstName" AS "employeeFirstName"`),
+            p(`"user"."lastName" AS "employeeLastName"`),
+            p(`"user"."username" AS "employeeUserName"`),
+            p(`"employee"."billRateCurrency" AS "billRateCurrency"`),
+            p(`"employee"."billRateValue" AS "billRateValue"`),
+            p(`"project"."name" AS "projectName"`),
+            p(`(COALESCE("workingDuration"."totalDuration", 0) / 3600.0) * COALESCE("employee"."billRateValue", 0) AS "billAmount"`)
+		])
+		.setParameters(workingDuration.getParameters())
+		.getRawMany();
+
+		return transformInvoiceData(bills);
 	}
 
 	/**

--- a/packages/core/src/lib/time-tracking/time-log/time-log.utils.ts
+++ b/packages/core/src/lib/time-tracking/time-log/time-log.utils.ts
@@ -1,8 +1,9 @@
 import * as moment from 'moment-timezone';
 import { reduce } from 'underscore';
-import { ArraySum } from '@gauzy/utils';
-import { ITimeLog, TimeLogPartialStatus, TimeLogType } from '@gauzy/contracts';
+import { ArraySum, isNotEmpty } from '@gauzy/utils';
+import { CurrenciesEnum, IInvoiceReport, ITimeLog, TimeLogPartialStatus, TimeLogType } from '@gauzy/contracts';
 import { getDateRangeFormat } from '../../core/utils';
+import { environment } from '@gauzy/config';
 
 /**
  * Calculates the average of an array of numbers.
@@ -184,4 +185,58 @@ export function calculateTotalDuration(
 ): number {
 	// Sum the clipped durations of all logs in the array
 	return logs.reduce((sum, log) => sum + calculateTimeLogDurationInRange(log, startDate, endDate, tz), 0);
+}
+
+export function transformInvoiceData(bills: {
+	employeeId: string,
+	employeeFirstName: string,
+	employeeLastName:string,
+	employeeUserName:string,
+	billRateCurrency: string | null,
+	billRateValue: string | null,
+	projectId: string,
+	projectName: string,
+	billAmount: string | null
+	totalDuration: string | null
+}[]): IInvoiceReport {
+
+	const billingSummaryMap = new Map<string, any>();
+
+	bills.forEach((bill) => {
+		if (!billingSummaryMap.has(bill.employeeId)) {
+			billingSummaryMap.set(bill.employeeId, {
+				id: bill.employeeId,
+				firstName: bill.employeeFirstName,
+				lastName: bill.employeeLastName,
+				userName: bill.employeeUserName,
+				billRateCurrency: isNotEmpty(bill.billRateCurrency) ? bill.billRateCurrency : environment.defaultCurrency as CurrenciesEnum,
+				billRateValue: isNotEmpty(bill.billRateValue) ? parseFloat(bill.billRateValue) : 0,
+				projects: [],
+				subTotalDuration: 0,
+				subTotalBillAmount: 0
+			});
+		}
+
+		const employee = billingSummaryMap.get(bill.employeeId);
+
+		employee.projects.push({
+			id: bill.projectId,
+			name: bill.projectName,
+			duration: isNotEmpty(bill.totalDuration) ? parseFloat(bill.totalDuration) : 0
+		});
+
+		employee.subTotalDuration += isNotEmpty(bill.totalDuration) ? parseFloat(bill.totalDuration) : 0;
+		employee.subTotalBillAmount += isNotEmpty(bill.billAmount) ? parseFloat(bill.billAmount) : 0;
+
+	})
+
+	const billingSummary = Array.from(billingSummaryMap.values());
+	const totalDuration = billingSummary.reduce((acc, curr) => acc + curr.subTotalDuration, 0);
+	const totalBillAmount = billingSummary.reduce((acc, curr) => acc + curr.subTotalBillAmount, 0);
+
+	return {
+		billingSummary,
+		totalDuration,
+		totalBillAmount
+	};
 }


### PR DESCRIPTION
# Ticket
[GZY-438 Generate Invoice Items by Project Hours](https://trello.com/c/bsQSkKGG/483-generate-invoice-items-by-project-hours)

# Description
What is the change?  
- Introduced new interfaces and types for invoice reporting, including IGetInvoiceReportInput and IInvoiceReport. 
- Implemented the getInvoice method in TimeLogService to retrieve invoice data based on specified filters. 
- Added InvoiceQueryDTO for validating invoice report requests.
- Enhanced TimeLogController with a new endpoint to fetch invoices by filters. 
- Updated utility functions to transform invoice data into the required report format.

Why is the change needed?  
This update introduces a new invoice generation method that returns the fully processed invoice in a single response. All necessary data is now retrieved with one database call, and the frontend no longer needs to request employee rate information separately.

As a result, the frontend is no longer responsible for assembling the invoice or combining data from multiple endpoints. Its only responsibility is to display the final invoice data. This simplifies the frontend logic, reduces network calls, and ensures consistency in invoice calculations.

# Scope of Changes
- [x] API change
- [ ] Frontend change
- [ ] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [x] I updated documentation where necessary
- [x] I ran the project and verified the change
- [x] Any dependent tasks/issues are linked above
