### PR TITLE
GZY-104 and GZY-328: Expand collapse button redundant for dashboard on side menu and close x and dropdown arrow icons disappear when multiple items are selected in dropdown fields

### DIFF
--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.html
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.html
@@ -2,7 +2,15 @@
 	*ngxPermissionsOnly="item?.data?.permissionKeys"
 	[ngClass]="state ? item?.class : item?.class + ' closed'"
 >
-	<nb-accordion-item [collapsed]="collapse" (collapsedChange)="onCollapse($event)" [ngClass]="{ opened: selected }">
+	<nb-accordion-item
+		[collapsed]="collapse"
+		(collapsedChange)="onCollapse($event)"
+		[ngClass]="{
+			opened: selected,
+			'has-children': item?.children?.length > 0,
+			'no-children': !item?.children?.length
+		}"
+	>
 		<nb-accordion-item-header
 			[gaTooltip]="item?.title"
 			[icon]="item?.icon"

--- a/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
+++ b/packages/ui-core/core/src/lib/components/sidebar-menu/menu-items/concrete/menu-item/menu-item.component.scss
@@ -136,3 +136,9 @@
     margin: 0 0.625rem;
   }
 }
+
+:host ::ng-deep .no-children {
+  nb-accordion-item-header .expansion-indicator {
+    display: none !important;
+  }
+}

--- a/packages/ui-core/shared/src/lib/invite/forms/email-invite-form/email-invite-form.component.scss
+++ b/packages/ui-core/shared/src/lib/invite/forms/email-invite-form/email-invite-form.component.scss
@@ -11,12 +11,6 @@
     padding-top: 2px;
   }
 
-  .adjust-height {
-    ::ng-deep .ng-select-container {
-      height: auto;
-    }
-  }
-
   ::ng-deep .custom-tag-list.nb-tag-list-with-input.size-medium {
     box-shadow: var(--gauzy-shadow) inset;
     background-color: var(--gauzy-card-2);
@@ -73,4 +67,12 @@
   nb-tag-list nb-tag::ng-deep {
     text-transform: initial;
   }
+}
+
+:host ::ng-deep .adjust-height .ng-select-container {
+  height: auto !important;
+}
+
+:host ::ng-deep .adjust-height.ng-select.ng-select-multiple .ng-value-container {
+  width: 50% !important;
 }


### PR DESCRIPTION
# Ticket
https://trello.com/c/lI2uB9zS/328-close-x-and-dropdown-arrow-icons-disappear-when-multiple-items-are-selected-in-dropdown-fields
https://trello.com/c/MwuQCeUo/104-expand-collapse-button-redundant-for-dashboard-on-side-menu

# Scope of Changes
- [ ] API change
- [x] Frontend change
- [ ] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [ ] I updated documentation where necessary
- [ ] I ran the project and verified the change
- [ ] Any dependent tasks/issues are linked above
