### PR TITLE
chore: update project references from Gauzy to DSpot ERP

### DIFF
--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -1,4 +1,4 @@
-# DSpot ERP Platform API (Core)
+# Ever Gauzy Platform API (Core)
 
 ARG DEPENDENCIES_IMAGE
 ARG GIT_HASH

--- a/.deploy/api/Dockerfile
+++ b/.deploy/api/Dockerfile
@@ -1,4 +1,4 @@
-# Ever Gauzy Platform API (Core)
+# DSpot ERP Platform API (Core)
 
 ARG DEPENDENCIES_IMAGE
 ARG GIT_HASH
@@ -107,7 +107,7 @@ ARG MIKRO_ORM_ALLOW_GLOBAL_CONTEXT
 FROM ${DEPENDENCIES_IMAGE:-"no-image"}:latest-api-dev AS builder
 
 LABEL maintainer="info@dspot.com.pl"
-LABEL org.opencontainers.image.source="https://github.com/DSpotDevelopers/gauzy"
+LABEL org.opencontainers.image.source="https://github.com/DSpotDevelopers/DSpot-ERP"
 
 ARG NODE_ENV
 ARG DEMO
@@ -158,6 +158,9 @@ RUN rm -rf ./node_modules/@gauzy \
 	done \
 	&& mv "./node_modules/@gauzy/plugin-sentry-tracing" "./node_modules/@gauzy/plugin-sentry" \
 	&& cp -r ./seed/* ./apps/api/public
+
+# AGPL-3.0 compliance: explicitly include license, attribution, and modification notice files
+COPY --chown=node:node LICENSE LICENSES.md CREDITS.md CHANGELOG.md README.md ./
 
 # Copy the entrypoint scripts
 COPY --chmod=755 wait .deploy/api/entrypoint.prod.sh .deploy/api/entrypoint.compose.sh ./

--- a/.deploy/api/Dockerfile.dockerignore
+++ b/.deploy/api/Dockerfile.dockerignore
@@ -21,6 +21,12 @@ docker-compose*.yml
 .travis.yml
 greenkeeper.json
 **/*.md
+# AGPL-3.0 compliance: preserve license and attribution files in Docker images
+!LICENSE*
+!LICENSES.md
+!CREDITS.md
+!CHANGELOG.md
+!README.md
 **/*.cmd
 **/*.log
 Jenkinsfile

--- a/.deploy/code-analysis/Dockerfile
+++ b/.deploy/code-analysis/Dockerfile
@@ -1,4 +1,4 @@
-# Gauzy image to run code analysis
+# DSpot ERP image to run code analysis
 
 ARG DEPENDENCIES_IMAGE
 

--- a/.deploy/code-analysis/Dockerfile.dockerignore
+++ b/.deploy/code-analysis/Dockerfile.dockerignore
@@ -28,6 +28,12 @@ docker-compose*.yml
 .travis.yml
 greenkeeper.json
 **/*.md
+# AGPL-3.0 compliance: preserve license and attribution files in Docker images
+!LICENSE*
+!LICENSES.md
+!CREDITS.md
+!CHANGELOG.md
+!README.md
 **/*.cmd
 **/*.log
 Jenkinsfile

--- a/.deploy/dependencies/api/Dockerfile
+++ b/.deploy/dependencies/api/Dockerfile
@@ -1,4 +1,4 @@
-# Gauzy API dependencies image
+# DSpot ERP API dependencies image
 
 ARG ENVIRONMENT=development
 
@@ -43,4 +43,5 @@ RUN if [ "$ENVIRONMENT" = "production" ]; then \
     && rm -rf node_modules/@angular* \
     && rm -rf node_modules/angular* \
     && rm -rf .angular \
-    && yarn cache clean
+    && yarn cache clean \
+    && rm -rf apps/ packages/ dist/ .scripts/ tools/

--- a/.deploy/dependencies/api/Dockerfile.dockerignore
+++ b/.deploy/dependencies/api/Dockerfile.dockerignore
@@ -28,6 +28,12 @@ docker-compose*.yml
 .travis.yml
 greenkeeper.json
 **/*.md
+# AGPL-3.0 compliance: preserve license and attribution files in Docker images
+!LICENSE*
+!LICENSES.md
+!CREDITS.md
+!CHANGELOG.md
+!README.md
 **/*.cmd
 **/*.log
 Jenkinsfile

--- a/.deploy/dependencies/webapp/Dockerfile
+++ b/.deploy/dependencies/webapp/Dockerfile
@@ -1,4 +1,4 @@
-# Gauzy dependencies image
+# DSpot ERP dependencies image
 
 FROM node:20.11.1-alpine3.19 AS gauzy-webapp-deps
 
@@ -32,4 +32,5 @@ RUN NODE_ENV=development yarn install \
     && rm -rf node_modules/passport* \
     && rm -rf node_modules/apollo-server* \
     && rm -rf .angular \
-    && yarn cache clean
+    && yarn cache clean \
+    && rm -rf apps/ packages/ dist/ .scripts/ tools/

--- a/.deploy/dependencies/webapp/Dockerfile.dockerignore
+++ b/.deploy/dependencies/webapp/Dockerfile.dockerignore
@@ -28,6 +28,12 @@ docker-compose*.yml
 .travis.yml
 greenkeeper.json
 **/*.md
+# AGPL-3.0 compliance: preserve license and attribution files in Docker images
+!LICENSE*
+!LICENSES.md
+!CREDITS.md
+!CHANGELOG.md
+!README.md
 **/*.cmd
 **/*.log
 Jenkinsfile

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -1,4 +1,4 @@
-# Ever Gauzy Platform UI
+# DSpot ERP Platform UI
 
 ARG DEPENDENCIES_IMAGE
 
@@ -59,7 +59,7 @@ ARG EXTENSION_DOWNLOAD_LINK
 FROM ${DEPENDENCIES_IMAGE:-"no-image"} AS builder
 
 LABEL maintainer="info@dspot.com.pl"
-LABEL org.opencontainers.image.source="https://github.com/DSpotDevelopers/gauzy"
+LABEL org.opencontainers.image.source="https://github.com/DSpotDevelopers/DSpot-ERP"
 
 # We make NODE_ENV and other env vars passed as build argument to be available in this stage
 ARG NODE_ENV
@@ -87,10 +87,13 @@ FROM nginx:alpine AS production
 
 WORKDIR /srv/gauzy
 
-# Copy the built API items and prepare dependencies
+# Copy the built webapp and prepare dependencies
 COPY --chown=nginx:nginx .deploy/webapp/nginx.compose.conf /etc/nginx/conf.d/compose.conf.template
 COPY --chown=nginx:nginx .deploy/webapp/nginx.prod.conf /etc/nginx/conf.d/prod.conf.template
 COPY --chown=nginx:nginx --from=builder /srv/gauzy/dist/apps/gauzy .
+
+# AGPL-3.0 compliance: include license, attribution, and modification notice files
+COPY --chown=nginx:nginx LICENSE LICENSES.md CREDITS.md CHANGELOG.md README.md ./
 
 # Copy the entrypoint scripts
 COPY  --chown=nginx:nginx --chmod=755 wait .deploy/webapp/entrypoint.compose.sh .deploy/webapp/entrypoint.prod.sh .deploy/webapp/replacements.sed ./
@@ -133,7 +136,7 @@ ENV CI=true \
 	FILE_PROVIDER=${FILE_PROVIDER:-"LOCAL"} \
 	PLATFORM_PRIVACY_URL=${PLATFORM_PRIVACY_URL:-"https://gauzy.co/privacy"} \
 	PLATFORM_TOS_URL=${PLATFORM_TOS_URL:-"https://gauzy.co/tos"} \
-	PROJECT_REPO=${PROJECT_REPO:-"https://github.com/DSpotDevelopers/gauzy"} \
+	PROJECT_REPO=${PROJECT_REPO:-"https://github.com/DSpotDevelopers/DSpot-ERP"} \
 	I18N_FILES_URL=${I18N_FILES_URL} \
 	COMPANY_NAME=${COMPANY_NAME:-"DSpot sp. z o.o."} \
 	COMPANY_LINK=${COMPANY_LINK:-"https://www.dspot.com.pl"} \

--- a/.deploy/webapp/Dockerfile
+++ b/.deploy/webapp/Dockerfile
@@ -1,4 +1,4 @@
-# DSpot ERP Platform UI
+# Ever Gauzy Platform UI
 
 ARG DEPENDENCIES_IMAGE
 

--- a/.deploy/webapp/Dockerfile.dockerignore
+++ b/.deploy/webapp/Dockerfile.dockerignore
@@ -21,6 +21,12 @@ docker-compose*.yml
 .travis.yml
 greenkeeper.json
 **/*.md
+# AGPL-3.0 compliance: preserve license and attribution files in Docker images
+!LICENSE*
+!LICENSES.md
+!CREDITS.md
+!CHANGELOG.md
+!README.md
 **/*.cmd
 **/*.log
 Jenkinsfile

--- a/.env.compose
+++ b/.env.compose
@@ -446,7 +446,7 @@ MOBILE_APP_DOWNLOAD_LINK='https://gauzy.co/downloads#mobile'
 EXTENSION_DOWNLOAD_LINK='https://gauzy.co/downloads#extensions'
 
 # Desktop Timer Application Configuration
-PROJECT_REPO='https://github.com/DSpotDevelopers/gauzy'
+PROJECT_REPO='https://github.com/DSpotDevelopers/DSpot-ERP'
 
 DESKTOP_TIMER_APP_NAME='dspot-erp-desktop-timer'
 DESKTOP_TIMER_APP_DESCRIPTION='DSpot ERP Desktop Timer'

--- a/.env.demo.compose
+++ b/.env.demo.compose
@@ -456,7 +456,7 @@ MOBILE_APP_DOWNLOAD_LINK='https://gauzy.co/downloads#mobile'
 EXTENSION_DOWNLOAD_LINK='https://gauzy.co/downloads#extensions'
 
 # Desktop Timer Application Configuration
-PROJECT_REPO='https://github.com/DSpotDevelopers/gauzy'
+PROJECT_REPO='https://github.com/DSpotDevelopers/DSpot-ERP'
 
 DESKTOP_TIMER_APP_NAME='dspot-erp-desktop-timer'
 DESKTOP_TIMER_APP_DESCRIPTION='DSpot ERP Desktop Timer'

--- a/.env.docker
+++ b/.env.docker
@@ -427,7 +427,7 @@ EXTENSION_DOWNLOAD_LINK='https://gauzy.co/downloads#extensions'
 
 
 # Desktop Timer Application Configuration
-PROJECT_REPO='https://github.com/DSpotDevelopers/gauzy'
+PROJECT_REPO='https://github.com/DSpotDevelopers/DSpot-ERP'
 DESKTOP_TIMER_APP_NAME='dspot-erp-desktop-timer'
 DESKTOP_TIMER_APP_DESCRIPTION='DSpot ERP Desktop Timer'
 DESKTOP_TIMER_APP_ID='pl.com.dspot.erpdesktoptimer'

--- a/.env.local
+++ b/.env.local
@@ -431,7 +431,7 @@ EXTENSION_DOWNLOAD_LINK='https://gauzy.co/downloads#extensions'
 
 
 # Desktop Timer Application Configuration
-PROJECT_REPO='https://github.com/DSpotDevelopers/gauzy'
+PROJECT_REPO='https://github.com/DSpotDevelopers/DSpot-ERP'
 
 DESKTOP_TIMER_APP_NAME='dspot-erp-desktop-timer'
 DESKTOP_TIMER_APP_DESCRIPTION='DSpot ERP Desktop Timer'

--- a/.env.sample
+++ b/.env.sample
@@ -443,7 +443,7 @@ MOBILE_APP_DOWNLOAD_LINK='https://gauzy.co/downloads#mobile'
 EXTENSION_DOWNLOAD_LINK='https://gauzy.co/downloads#extensions'
 
 # Desktop Timer Application Configuration
-PROJECT_REPO='https://github.com/DSpotDevelopers/gauzy'
+PROJECT_REPO='https://github.com/DSpotDevelopers/DSpot-ERP'
 
 DESKTOP_TIMER_APP_NAME='dspot-erp-desktop-timer'
 DESKTOP_TIMER_APP_DESCRIPTION='DSpot ERP Desktop Timer'

--- a/.scripts/env.ts
+++ b/.scripts/env.ts
@@ -247,7 +247,7 @@ export const env: Env = cleanEnv(
 			default: 'https://www.linkedin.com/company/dspotteam'
 		}),
 		PROJECT_REPO: str({
-			default: 'https://github.com/DSpotDevelopers/gauzy'
+			default: 'https://github.com/DSpotDevelopers/DSpot-ERP'
 		}),
 
 		DESKTOP_TIMER_APP_NAME: str({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         stage("Clone") {
             steps{
                 git branch: 'develop',
-                    url: 'https://github.com/DSpotDevelopers/gauzy'
+                    url: 'https://github.com/DSpotDevelopers/DSpot-ERP'
 
                 sh """
                     curl 'https://api.github.com/repos/ever-co/${REPO_NAME}/statuses/$GIT_COMMIT' -H 'Authorization: token ${GITHUB_TOKEN}' -H 'Content-Type: application/json' -X POST -d '{"state": "pending", "context": "Jenkins", "description": "Jenkins pipeline is running", "target_url": "https://$CI_URL/job/${JOB_NAME}/$BUILD_NUMBER/console"}'

--- a/packages/core/src/lib/email-template/queries/handlers/email-template.generate-preview.handler.ts
+++ b/packages/core/src/lib/email-template/queries/handlers/email-template.generate-preview.handler.ts
@@ -73,7 +73,7 @@ export class EmailTemplateGeneratePreviewHandler implements IQueryHandler<EmailT
 			task_status: 'In Progress',
 			task_update_project: 'DSpot ERP Project',
 			task_update_assign_by: 'Ruslan Konviser',
-			task_update_url: 'https://github.com/DSpotDevelopers/gauzy/issues/1688',
+			task_update_url: 'https://github.com/DSpotDevelopers/DSpot-ERP/issues/1688',
 			inviteCode: generateAlphaNumericCode(ALPHA_NUMERIC_CODE_LENGTH),
 			teams: 'DSpot ERP Team',
 			verificationCode: generateAlphaNumericCode(ALPHA_NUMERIC_CODE_LENGTH),
@@ -85,7 +85,7 @@ export class EmailTemplateGeneratePreviewHandler implements IQueryHandler<EmailT
 				{
 					tenantName: 'Default',
 					userName: 'Default',
-					resetLink: 'https://github.com/DSpotDevelopers/gauzy'
+					resetLink: 'https://github.com/DSpotDevelopers/DSpot-ERP'
 				}
 			],
 			companyLink,


### PR DESCRIPTION
Update all project references, URLs, and documentation to reflect the rename from "Gauzy" to "DSpot ERP". This includes:
- Renaming Docker image descriptions and labels
- Updating GitHub repository URLs in environment files and Jenkins configuration
- Adding AGPL-3.0 compliance exceptions to Docker ignore files to preserve license and attribution files
- Including license and documentation files in Docker images for compliance
- Cleaning up unnecessary directories in dependency images to reduce image size
- Updating example URLs in email template preview handler

# Ticket
[Please link the ticket or issue ](https://trello.com/c/lbWB9dFn/538-preserve-agpl-license-text-copyright-notices)

# Description
What is the change?  
- Provide a summary of what was changed, added, or removed.

Why is the change needed?  
- Explain the motivation and the problem this change solves. Include any relevant context or background.

# How to test the change
- If the change cannot be fully automated, include manual steps to apply it (commands, DB updates, config changes, feature flags to toggle, etc.)

# Screenshots (if apply)
- If the change includes UI updates, attach screenshots or a short screen recording showing the before and after. 

# Scope of Changes
- [ ] API change
- [ ] Frontend change
- [x] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [ ] I updated documentation where necessary
- [ ] I ran the project and verified the change
- [ ] Any dependent tasks/issues are linked above
