### PR TITLE
GZY-310: Add asterisk for the optional taskId field

### DIFF
--- a/packages/ui-core/shared/src/lib/project-module/project-module-mutation/project-module-mutation.component.html
+++ b/packages/ui-core/shared/src/lib/project-module/project-module-mutation/project-module-mutation.component.html
@@ -128,10 +128,16 @@
 			<div class="row">
 				<div class="col-sm-12">
 					<div class="form-group">
-						<label>{{ 'TIMER_TRACKER.SELECT_TASK' | translate }}</label>
+						<label class="label" [ngClass]="organization?.requireTask ? 'required-asterisk' : null">
+							{{ 'TIMER_TRACKER.SELECT_TASK' | translate }}
+						</label>
 						<ga-task-selector name="taskId" [projectId]="form.get('projectId').value"
 							formControlName="tasks" [multiple]="true"
 							[required]="organization?.requireTask"></ga-task-selector>
+						<div *ngIf="organization?.requireTask && form.get('tasks')?.errors?.required &&
+						 form.get('tasks')?.touched" class="invalid-feedback d-block">
+							{{ 'TIMER_TRACKER.VALIDATION.TASK_REQUIRED' | translate }}
+						</div>
 					</div>
 				</div>
 			</div>

--- a/packages/ui-core/shared/src/lib/project-module/project-module-mutation/project-module-mutation.component.html
+++ b/packages/ui-core/shared/src/lib/project-module/project-module-mutation/project-module-mutation.component.html
@@ -128,13 +128,14 @@
 			<div class="row">
 				<div class="col-sm-12">
 					<div class="form-group">
-						<label class="label" [ngClass]="organization?.requireTask ? 'required-asterisk' : null">
+						<label class="label"
+							[ngClass]="form.get('tasks')?.errors?.required ? 'required-asterisk' : null">
 							{{ 'TIMER_TRACKER.SELECT_TASK' | translate }}
 						</label>
 						<ga-task-selector name="taskId" [projectId]="form.get('projectId').value"
 							formControlName="tasks" [multiple]="true"
 							[required]="organization?.requireTask"></ga-task-selector>
-						<div *ngIf="organization?.requireTask && form.get('tasks')?.errors?.required &&
+						<div *ngIf="form.get('tasks')?.errors?.required &&
 						 form.get('tasks')?.touched" class="invalid-feedback d-block">
 							{{ 'TIMER_TRACKER.VALIDATION.TASK_REQUIRED' | translate }}
 						</div>


### PR DESCRIPTION
# Ticket
https://trello.com/c/iin7x1eL/310-required-fields-not-marked-with-asterisk-in-add-edit-module-forms

# Description
What is the change?  
- An asterix has been added for the optional taskId field

# Scope of Changes
- [ ] API change
- [x] Frontend change
- [ ] DevOps change

# Checklist
- [ ] I have added/updated relevant tests
- [ ] I have removed any commented code
- [ ] I updated documentation where necessary
- [x] I ran the project and verified the change
- [x] Any dependent tasks/issues are linked above
